### PR TITLE
build: publish right-round releases to homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,3 +34,15 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^chore:"
+
+brews:
+  - repository:
+      owner: cboone
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/cboone/right-round"
+    description: "Browse and preview terminal progress indicators"
+    license: MIT
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/right-round --version")

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Navigate, preview live animations, and copy entries as JSON.
 
 ## Installation
 
+### Homebrew
+
+```sh
+brew install cboone/tap/right-round
+```
+
 ### From source
 
 ```sh


### PR DESCRIPTION
## Summary
- add GoReleaser Homebrew `brews` publishing config targeting `cboone/homebrew-tap`
- pass `HOMEBREW_TAP_TOKEN` in the release workflow
- add Homebrew install instructions to the README

## Validation
- go test ./...