### PR TITLE
chore: add vet target, update go-ci.yml to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v1
+    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v2
     with:
       go-version: "1.25.0"
       run-lint: true

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OUTDIR  := bin
 
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build install clean lint test run tidy
+.PHONY: build install clean lint vet test run tidy
 
 build:
 	mkdir -p $(OUTDIR)
@@ -18,6 +18,9 @@ clean:
 
 lint:
 	golangci-lint run ./...
+
+vet: ## Run go vet
+	go vet ./...
 
 test:
 	go test ./... -race -coverprofile=coverage.out


### PR DESCRIPTION
## Summary

- Add `vet` Makefile target (`go vet ./...`)
- Update go-ci.yml reference from `@v1` to `@v2`

go-ci.yml v2 always runs `make vet` in the test job.

## Test plan

- [ ] CI passes with go-ci.yml@v2
- [ ] `make vet` works locally